### PR TITLE
Fix code scanning alert no. 28: Incomplete multi-character sanitization

### DIFF
--- a/aperture-examples/src/main/javascript/lib/jquery.js
+++ b/aperture-examples/src/main/javascript/lib/jquery.js
@@ -6298,7 +6298,14 @@ jQuery.fn.extend({
 						jQuery("<div>")
 							// inject the contents of the document in, removing the scripts
 							// to avoid any 'Permission Denied' errors in IE
-							.append(responseText.replace(rscript, ""))
+							.append((function sanitize(input) {
+								let previous;
+								do {
+									previous = input;
+									input = input.replace(rscript, "");
+								} while (input !== previous);
+								return input;
+							})(responseText))
 
 							// Locate the specified elements
 							.find(selector) :


### PR DESCRIPTION
Fixes [https://github.com/drzo/aperturejs/security/code-scanning/28](https://github.com/drzo/aperturejs/security/code-scanning/28)

To fix the problem, we should ensure that all instances of the targeted pattern are removed from the input. One effective way to achieve this is to apply the regular expression replacement repeatedly until no more replacements can be performed. This ensures that any remaining unsafe content is fully removed. Alternatively, we can use a well-tested sanitization library like `sanitize-html` to handle the sanitization process more robustly.

In this case, we will implement the repeated replacement approach to ensure that all instances of the `<script>` tags are removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
